### PR TITLE
Remove debug console logs

### DIFF
--- a/src/components/CompetitorAnalysis.js
+++ b/src/components/CompetitorAnalysis.js
@@ -114,15 +114,12 @@ const CompetitorAnalysis = ({ selectedMarket }) => {
 
   useEffect(() => {
     if (selectedMarket) {
-      console.log('Loading data for market:', selectedMarket);
       const competitorData = getCompetitorData(selectedMarket);
-      console.log('Loaded data:', competitorData);
       setData(competitorData);
     }
   }, [selectedMarket]);
 
   if (!data) {
-    console.log('No data available');
     return null;
   }
 

--- a/src/components/DashboardIntro.js
+++ b/src/components/DashboardIntro.js
@@ -192,15 +192,6 @@ const DashboardIntro = ({ selectedMarket }) => {
       return () => clearTimeout(timeout);
     }
   };
-
-  // Enhanced console logging for debugging
-  console.log('DashboardIntro Debug:');
-  console.log('- Selected Market:', selectedMarket);
-  console.log('- Available Market Keys:', Object.keys(marketSources));
-  console.log('- Found Market Key:', marketKey);
-  console.log('- Sources Array:', sources);
-  console.log('- Tab Value:', tabValue);
-
   return (
     <Paper sx={{ p: 4, background: '#f8fafc' }}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>


### PR DESCRIPTION
## Summary
- clean up DashboardIntro and CompetitorAnalysis by removing console.log statements

## Testing
- `CI=true npm test --silent` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68594fe9971c8331a8422a14405bbd9a