### PR TITLE
Use env variable for login password

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -23,7 +23,14 @@ const Login = ({ onLogin }) => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (password === '1234') {
+    const expectedPassword = process.env.REACT_APP_LOGIN_PASSWORD;
+
+    if (!expectedPassword) {
+      setError('Login password not configured.');
+      return;
+    }
+
+    if (password === expectedPassword) {
       onLogin(true);
     } else {
       setError('Invalid password. Please try again.');


### PR DESCRIPTION
## Summary
- load login password from `REACT_APP_LOGIN_PASSWORD`
- show an error if the variable isn't provided

## Testing
- `npm test -- --watchAll=false` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685961f1e8b88331b473b1207bd2794d