### PR TITLE
Add R12GS consumer filtering and charts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, lazy, Suspense } from "react";
 import { ThemeProvider } from "@mui/material/styles";
 import {
   Container,
@@ -21,12 +21,13 @@ import MarketWRIScoreCards from "./components/MarketWRIScoreCards";
 import WRIStrategicDirection from "./components/WRIStrategicDirection";
 import AttributeResonanceDefinition from "./components/AttributeResonanceDefinition";
 import MarketRecommendations from "./components/MarketRecommendations";
-import R12GSConsumerAnalysis from "./components/R12GSConsumerAnalysis";
 import AIChatPanel from "./components/AIChatPanel";
 import AIFloatingButton from "./components/AIFloatingButton";
 import bmwLogo from "./assets/bmw-black.jpg";
 import Login from "./components/Login";
 import { r12gsConsumerData } from './data/r12gsConsumerData';
+
+const R12GSConsumerAnalysis = lazy(() => import("./components/R12GSConsumerAnalysis"));
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -214,10 +215,12 @@ function App() {
             </TabPanel>
 
             <TabPanel value={currentTab} index={6}>
-              <R12GSConsumerAnalysis
-                selectedMarket={selectedMarket}
-                data={r12gsConsumerData}
-              />
+              <Suspense fallback={<div>Loading...</div>}>
+                <R12GSConsumerAnalysis
+                  selectedMarket={selectedMarket}
+                  data={r12gsConsumerData}
+                />
+              </Suspense>
             </TabPanel>
 
             <Box

--- a/src/components/CompetitiveIntelCharts.js
+++ b/src/components/CompetitiveIntelCharts.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+import { Card, CardContent, Typography } from '@mui/material';
+
+const CompetitiveIntelCharts = ({ data }) => (
+  <Card elevation={3} sx={{ height: '100%' }}>
+    <CardContent>
+      <Typography variant="h6" sx={{ fontFamily: 'BMW Motorrad', mb: 2, color: '#1a1a1a' }}>
+        Competitor Mentions
+      </Typography>
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={data}>
+          <XAxis dataKey="competitor" />
+          <YAxis allowDecimals={false} />
+          <Tooltip />
+          <Bar dataKey="count" fill="#1976d2" />
+        </BarChart>
+      </ResponsiveContainer>
+    </CardContent>
+  </Card>
+);
+
+export default CompetitiveIntelCharts;

--- a/src/components/PlatformAnalysis.js
+++ b/src/components/PlatformAnalysis.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts';
+import { Card, CardContent, Typography } from '@mui/material';
+
+const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8e24aa', '#607d8b'];
+
+const PlatformAnalysis = ({ data }) => (
+  <Card elevation={3} sx={{ height: '100%' }}>
+    <CardContent>
+      <Typography variant="h6" sx={{ fontFamily: 'BMW Motorrad', mb: 2, color: '#1a1a1a' }}>
+        Platform Analysis
+      </Typography>
+      <ResponsiveContainer width="100%" height={300}>
+        <PieChart>
+          <Pie data={data} dataKey="value" nameKey="platform" outerRadius={100} label>
+            {data.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ResponsiveContainer>
+    </CardContent>
+  </Card>
+);
+
+export default PlatformAnalysis;

--- a/src/components/PurchaseIntentFunnel.js
+++ b/src/components/PurchaseIntentFunnel.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+import { Card, CardContent, Typography } from '@mui/material';
+
+const PurchaseIntentFunnel = ({ data }) => (
+  <Card elevation={3} sx={{ height: '100%' }}>
+    <CardContent>
+      <Typography variant="h6" sx={{ fontFamily: 'BMW Motorrad', mb: 2, color: '#1a1a1a' }}>
+        Purchase Intent
+      </Typography>
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={data} layout="vertical">
+          <XAxis type="number" domain={[0, 'dataMax']} hide />
+          <YAxis type="category" dataKey="intent" width={100} />
+          <Tooltip />
+          <Bar dataKey="count" fill="#1976d2" />
+        </BarChart>
+      </ResponsiveContainer>
+    </CardContent>
+  </Card>
+);
+
+export default PurchaseIntentFunnel;

--- a/src/components/QuoteExplorer.js
+++ b/src/components/QuoteExplorer.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import {
+  Card,
+  CardContent,
+  Typography,
+  Grid,
+  TextField,
+  MenuItem,
+  Box,
+  Chip
+} from '@mui/material';
+
+const QuoteExplorer = ({ filters, onFilterChange, quotes, themes, sentiments, platforms, weeks, purchaseIntents, competitors }) => {
+  const handleChange = (field) => (event) => {
+    onFilterChange({ ...filters, [field]: event.target.value });
+  };
+
+  return (
+    <Card elevation={3} sx={{ mb: 4 }}>
+      <CardContent>
+        <Typography variant="h6" sx={{ fontFamily: 'BMW Motorrad', mb: 2, color: '#1a1a1a' }}>
+          Quote Explorer
+        </Typography>
+        <Grid container spacing={2} sx={{ mb: 2 }}>
+          <Grid item xs={6} md={2}>
+            <TextField select label="Theme" fullWidth value={filters.theme} onChange={handleChange('theme')} size="small">
+              <MenuItem value="All">All</MenuItem>
+              {themes.map((t) => (
+                <MenuItem key={t} value={t}>{t}</MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+          <Grid item xs={6} md={2}>
+            <TextField select label="Sentiment" fullWidth value={filters.sentiment} onChange={handleChange('sentiment')} size="small">
+              <MenuItem value="All">All</MenuItem>
+              {sentiments.map((s) => (
+                <MenuItem key={s} value={s}>{s}</MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+          <Grid item xs={6} md={2}>
+            <TextField select label="Platform" fullWidth value={filters.platform} onChange={handleChange('platform')} size="small">
+              <MenuItem value="All">All</MenuItem>
+              {platforms.map((p) => (
+                <MenuItem key={p} value={p}>{p}</MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+          <Grid item xs={6} md={2}>
+            <TextField select label="Week" fullWidth value={filters.week} onChange={handleChange('week')} size="small">
+              <MenuItem value="All">All</MenuItem>
+              {weeks.map((w) => (
+                <MenuItem key={w} value={w}>{w}</MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+          <Grid item xs={6} md={2}>
+            <TextField select label="Intent" fullWidth value={filters.purchaseIntent} onChange={handleChange('purchaseIntent')} size="small">
+              <MenuItem value="All">All</MenuItem>
+              {purchaseIntents.map((pi) => (
+                <MenuItem key={pi} value={pi}>{pi}</MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+          <Grid item xs={6} md={2}>
+            <TextField select label="Competitor" fullWidth value={filters.competitor} onChange={handleChange('competitor')} size="small">
+              <MenuItem value="All">All</MenuItem>
+              {competitors.map((c) => (
+                <MenuItem key={c} value={c}>{c}</MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+        </Grid>
+        <Box sx={{ maxHeight: 300, overflowY: 'auto' }}>
+          {quotes.map((q) => (
+            <Box key={q.id} sx={{ mb: 2 }}>
+              <Typography variant="body2" sx={{ fontFamily: 'BMW Motorrad', mb: 0.5 }}>
+                "{q.text}"
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                <Chip label={q.theme} size="small" />
+                <Chip label={q.sentiment} size="small" />
+                <Chip label={q.platform} size="small" />
+                {q.week && <Chip label={`Week ${q.week}`} size="small" />}
+                <Chip label={q.purchaseIntent} size="small" />
+                {q.competitorMentioned !== 'NONE' && <Chip label={q.competitorMentioned} size="small" />}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default QuoteExplorer;

--- a/src/components/R12GSConsumerAnalysis.js
+++ b/src/components/R12GSConsumerAnalysis.js
@@ -1,23 +1,124 @@
-import React from 'react';
-import { 
-  Box, 
-  Typography, 
-  Grid, 
-  Card, 
-  CardContent, 
+import React, { useMemo, useState } from 'react';
+import {
+  Box,
+  Typography,
+  Grid,
   Paper,
   Chip,
   Divider,
-  useTheme
+  Card,
+  CardContent
 } from '@mui/material';
-import { PieChart, Pie, Cell, ResponsiveContainer, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar } from 'recharts';
+import ThemeCharts from './ThemeCharts';
+import SentimentTimeline from './SentimentTimeline';
+import QuoteExplorer from './QuoteExplorer';
+import PurchaseIntentFunnel from './PurchaseIntentFunnel';
+import CompetitiveIntelCharts from './CompetitiveIntelCharts';
+import PlatformAnalysis from './PlatformAnalysis';
 
 const R12GSConsumerAnalysis = ({ selectedMarket, data }) => {
-  const theme = useTheme();
   const marketKey = selectedMarket.toLowerCase();
-  const marketData = data[marketKey];
+  const marketData = data[marketKey] || {};
+  const noData = !data[marketKey];
 
-  if (!marketData) {
+  const {
+    keyInsights = {},
+    consumerTimeline = [],
+    consumerQuotes = [],
+    consumerConcerns = []
+  } = marketData;
+
+  const allThemes = Array.from(new Set(consumerQuotes.map((q) => q.theme)));
+  const allSentiments = Array.from(new Set(consumerQuotes.map((q) => q.sentiment)));
+  const allPlatforms = Array.from(new Set(consumerQuotes.map((q) => q.platform)));
+  const allWeeks = Array.from(new Set(consumerQuotes.map((q) => q.week).filter(Boolean)));
+  const allPurchaseIntents = Array.from(new Set(consumerQuotes.map((q) => q.purchaseIntent)));
+  const allCompetitors = Array.from(
+    new Set(consumerQuotes.map((q) => q.competitorMentioned).filter((c) => c && c !== 'NONE'))
+  );
+
+  const [filters, setFilters] = useState({
+    theme: 'All',
+    sentiment: 'All',
+    platform: 'All',
+    week: 'All',
+    purchaseIntent: 'All',
+    competitor: 'All'
+  });
+
+  const filteredQuotes = useMemo(() => {
+    return consumerQuotes.filter((q) =>
+      [
+        filters.theme === 'All' || q.theme === filters.theme,
+        filters.sentiment === 'All' || q.sentiment === filters.sentiment,
+        filters.platform === 'All' || q.platform === filters.platform,
+        filters.week === 'All' || q.week === filters.week,
+        filters.purchaseIntent === 'All' || q.purchaseIntent === filters.purchaseIntent,
+        filters.competitor === 'All' || q.competitorMentioned === filters.competitor
+      ].every(Boolean)
+    );
+  }, [consumerQuotes, filters]);
+
+  const themeData = useMemo(() => {
+    const counts = {};
+    filteredQuotes.forEach((q) => {
+      counts[q.theme] = (counts[q.theme] || 0) + 1;
+    });
+    return Object.entries(counts).map(([theme, count]) => ({
+      subject: theme.length > 20 ? theme.substring(0, 20) + '...' : theme,
+      A: count,
+      fullMark: Math.max(...Object.values(counts), 1)
+    }));
+  }, [filteredQuotes]);
+
+  const platformData = useMemo(() => {
+    const counts = {};
+    filteredQuotes.forEach((q) => {
+      counts[q.platform] = (counts[q.platform] || 0) + 1;
+    });
+    return Object.entries(counts).map(([platform, count]) => ({
+      platform,
+      value: count
+    }));
+  }, [filteredQuotes]);
+
+  const purchaseIntentData = useMemo(() => {
+    const counts = {};
+    filteredQuotes.forEach((q) => {
+      counts[q.purchaseIntent] = (counts[q.purchaseIntent] || 0) + 1;
+    });
+    return Object.entries(counts).map(([intent, count]) => ({ intent, count }));
+  }, [filteredQuotes]);
+
+  const competitorData = useMemo(() => {
+    const counts = {};
+    filteredQuotes.forEach((q) => {
+      if (q.competitorMentioned && q.competitorMentioned !== 'NONE') {
+        counts[q.competitorMentioned] = (counts[q.competitorMentioned] || 0) + 1;
+      }
+    });
+    return Object.entries(counts).map(([competitor, count]) => ({ competitor, count }));
+  }, [filteredQuotes]);
+
+  const parseSentiment = (text) => {
+    const result = { positive: 0, neutral: 0, negative: 0 };
+    if (!text) return result;
+    const regex = /(\d+)%\s*(positive|negative|neutral)/gi;
+    let m;
+    while ((m = regex.exec(text))) {
+      result[m[2].toLowerCase()] = parseInt(m[1], 10);
+    }
+    return result;
+  };
+
+  const timelineData = useMemo(() => {
+    return consumerTimeline.map((w) => ({
+      week: w.week,
+      ...parseSentiment(w.sentiment)
+    }));
+  }, [consumerTimeline]);
+
+  if (noData) {
     return (
       <Typography sx={{ fontFamily: 'BMW Motorrad' }}>
         No R 12 G/S consumer data available for {selectedMarket}.
@@ -25,133 +126,45 @@ const R12GSConsumerAnalysis = ({ selectedMarket, data }) => {
     );
   }
 
-  const { 
-    consumerReactionThemes = {}, 
-    sentimentAnalysis = {}, 
-    keyInsights = {},
-    platformDistribution = {},
-    consumerTimeline = [],
-    consumerQuotes = [],
-    consumerConcerns = []
-  } = marketData;
-
-  // Prepare data for pie chart (sentiment)
-  const sentimentData = Object.entries(sentimentAnalysis).map(([key, value]) => ({
-    name: key.charAt(0).toUpperCase() + key.slice(1),
-    value: value,
-    color: key === 'positive' ? '#4caf50' : key === 'negative' ? '#f44336' : '#ff9800'
-  }));
-
-  // Prepare data for radar chart (themes)
-  const themeData = Object.entries(consumerReactionThemes).map(([theme, value]) => ({
-    subject: theme.length > 20 ? theme.substring(0, 20) + '...' : theme,
-    A: value,
-    fullMark: 25
-  }));
-
-  // Platform distribution data
-  const platformData = Object.entries(platformDistribution).map(([platform, value]) => ({
-    name: platform,
-    value: value
-  }));
-
   return (
     <Box sx={{ p: 3 }}>
       <Typography variant="h4" sx={{ fontFamily: 'BMW Motorrad', mb: 4, color: '#1a1a1a' }}>
         R 12 G/S Consumer Analysis - {selectedMarket}
       </Typography>
 
-      {/* Sentiment Analysis Pie Chart */}
+      <QuoteExplorer
+        filters={filters}
+        onFilterChange={setFilters}
+        quotes={filteredQuotes}
+        themes={allThemes}
+        sentiments={allSentiments}
+        platforms={allPlatforms}
+        weeks={allWeeks}
+        purchaseIntents={allPurchaseIntents}
+        competitors={allCompetitors}
+      />
+
       <Grid container spacing={3} sx={{ mb: 4 }}>
         <Grid item xs={12} md={6}>
-          <Card elevation={3} sx={{ height: '100%' }}>
-            <CardContent>
-              <Typography variant="h6" sx={{ fontFamily: 'BMW Motorrad', mb: 2, color: '#1a1a1a' }}>
-                Sentiment Analysis
-              </Typography>
-              <ResponsiveContainer width="100%" height={300}>
-                <PieChart>
-                  <Pie
-                    data={sentimentData}
-                    cx="50%"
-                    cy="50%"
-                    innerRadius={60}
-                    outerRadius={100}
-                    paddingAngle={5}
-                    dataKey="value"
-                  >
-                    {sentimentData.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill={entry.color} />
-                    ))}
-                  </Pie>
-                </PieChart>
-              </ResponsiveContainer>
-              <Box sx={{ display: 'flex', justifyContent: 'center', gap: 2, mt: 2 }}>
-                {sentimentData.map((item, index) => (
-                  <Box key={index} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <Box sx={{ width: 12, height: 12, backgroundColor: item.color, borderRadius: '50%' }} />
-                    <Typography variant="body2">{item.name}: {item.value}%</Typography>
-                  </Box>
-                ))}
-              </Box>
-            </CardContent>
-          </Card>
+          <ThemeCharts data={themeData} />
         </Grid>
-
-        {/* Consumer Reaction Themes Radar Chart */}
         <Grid item xs={12} md={6}>
-          <Card elevation={3} sx={{ height: '100%' }}>
-            <CardContent>
-              <Typography variant="h6" sx={{ fontFamily: 'BMW Motorrad', mb: 2, color: '#1a1a1a' }}>
-                Consumer Reaction Themes
-              </Typography>
-              <ResponsiveContainer width="100%" height={300}>
-                <RadarChart data={themeData}>
-                  <PolarGrid />
-                  <PolarAngleAxis dataKey="subject" />
-                  <PolarRadiusAxis angle={90} domain={[0, 25]} />
-                  <Radar
-                    name="Themes"
-                    dataKey="A"
-                    stroke="#1976d2"
-                    fill="#1976d2"
-                    fillOpacity={0.3}
-                  />
-                </RadarChart>
-              </ResponsiveContainer>
-            </CardContent>
-          </Card>
+          <PlatformAnalysis data={platformData} />
         </Grid>
       </Grid>
 
-      {/* Platform Distribution */}
+      <Grid container spacing={3} sx={{ mb: 4 }}>
+        <Grid item xs={12} md={6}>
+          <PurchaseIntentFunnel data={purchaseIntentData} />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <CompetitiveIntelCharts data={competitorData} />
+        </Grid>
+      </Grid>
+
       <Grid container spacing={3} sx={{ mb: 4 }}>
         <Grid item xs={12}>
-          <Card elevation={3}>
-            <CardContent>
-              <Typography variant="h6" sx={{ fontFamily: 'BMW Motorrad', mb: 2, color: '#1a1a1a' }}>
-                Platform Distribution
-              </Typography>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
-                {platformData.map((platform, index) => (
-                  <Chip
-                    key={index}
-                    label={`${platform.name}: ${platform.value}%`}
-                    variant="outlined"
-                    sx={{
-                      fontFamily: 'BMW Motorrad',
-                      borderColor: '#1976d2',
-                      color: '#1976d2',
-                      '&:hover': {
-                        backgroundColor: '#1976d2',
-                        color: 'white'
-                      }
-                    }}
-                  />
-                ))}
-              </Box>
-            </CardContent>
-          </Card>
+          <SentimentTimeline data={timelineData} />
         </Grid>
       </Grid>
 

--- a/src/components/SentimentTimeline.js
+++ b/src/components/SentimentTimeline.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts';
+import { Card, CardContent, Typography } from '@mui/material';
+
+const SentimentTimeline = ({ data }) => (
+  <Card elevation={3} sx={{ height: '100%' }}>
+    <CardContent>
+      <Typography variant="h6" sx={{ fontFamily: 'BMW Motorrad', mb: 2, color: '#1a1a1a' }}>
+        Sentiment Timeline
+      </Typography>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={data}>
+          <XAxis dataKey="week" />
+          <YAxis domain={[0, 100]} />
+          <Tooltip />
+          <Legend />
+          <Line type="monotone" dataKey="positive" stroke="#4caf50" />
+          <Line type="monotone" dataKey="neutral" stroke="#ff9800" />
+          <Line type="monotone" dataKey="negative" stroke="#f44336" />
+        </LineChart>
+      </ResponsiveContainer>
+    </CardContent>
+  </Card>
+);
+
+export default SentimentTimeline;

--- a/src/components/ThemeCharts.js
+++ b/src/components/ThemeCharts.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ResponsiveContainer, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar } from 'recharts';
+import { Card, CardContent, Typography } from '@mui/material';
+
+const ThemeCharts = ({ data }) => (
+  <Card elevation={3} sx={{ height: '100%' }}>
+    <CardContent>
+      <Typography variant="h6" sx={{ fontFamily: 'BMW Motorrad', mb: 2, color: '#1a1a1a' }}>
+        Themes
+      </Typography>
+      <ResponsiveContainer width="100%" height={300}>
+        <RadarChart data={data}>
+          <PolarGrid />
+          <PolarAngleAxis dataKey="subject" />
+          <PolarRadiusAxis angle={90} domain={[0, 25]} />
+          <Radar name="Themes" dataKey="A" stroke="#1976d2" fill="#1976d2" fillOpacity={0.3} />
+        </RadarChart>
+      </ResponsiveContainer>
+    </CardContent>
+  </Card>
+);
+
+export default ThemeCharts;


### PR DESCRIPTION
## Summary
- create ThemeCharts, SentimentTimeline, QuoteExplorer, PurchaseIntentFunnel
- add CompetitiveIntelCharts and PlatformAnalysis components
- enhance R12GSConsumerAnalysis with multi-dimensional filtering
- lazy-load R12GSConsumerAnalysis in App and wrap with `Suspense`

## Testing
- `npm run lint`
- `npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_b_685be18ff970833190781b099153c2c6