### PR TITLE
Add virtualized quote list

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
     "react-pdf": "^7.7.0",
+    "react-window": "^1.8.8",
     "react-scripts": "5.0.1",
     "recharts": "^2.15.4",
     "rehype-highlight": "^7.0.2",

--- a/src/components/QuoteExplorer.js
+++ b/src/components/QuoteExplorer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import {
   Card,
   CardContent,
@@ -11,9 +11,42 @@ import {
 } from '@mui/material';
 
 const QuoteExplorer = ({ filters, onFilterChange, quotes, themes, sentiments, platforms, weeks, purchaseIntents, competitors }) => {
+  const listRef = useRef(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const rowHeight = 80;
+  const containerHeight = 300;
+
   const handleChange = (field) => (event) => {
     onFilterChange({ ...filters, [field]: event.target.value });
   };
+
+  const handleScroll = () => {
+    if (listRef.current) {
+      setScrollTop(listRef.current.scrollTop);
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((prev) => Math.min(prev + 1, quotes.length - 1));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((prev) => Math.max(prev - 1, 0));
+    }
+  };
+
+  useEffect(() => {
+    if (activeIndex >= 0 && listRef.current) {
+      listRef.current.scrollTo({ top: activeIndex * rowHeight, behavior: 'smooth' });
+    }
+  }, [activeIndex]);
+
+  const startIndex = Math.floor(scrollTop / rowHeight);
+  const visibleCount = Math.ceil(containerHeight / rowHeight) + 1;
+  const visibleQuotes = quotes.slice(startIndex, startIndex + visibleCount);
+  const offsetY = startIndex * rowHeight;
 
   return (
     <Card elevation={3} sx={{ mb: 4 }}>
@@ -71,22 +104,53 @@ const QuoteExplorer = ({ filters, onFilterChange, quotes, themes, sentiments, pl
             </TextField>
           </Grid>
         </Grid>
-        <Box sx={{ maxHeight: 300, overflowY: 'auto' }}>
-          {quotes.map((q) => (
-            <Box key={q.id} sx={{ mb: 2 }}>
-              <Typography variant="body2" sx={{ fontFamily: 'BMW Motorrad', mb: 0.5 }}>
-                "{q.text}"
-              </Typography>
-              <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                <Chip label={q.theme} size="small" />
-                <Chip label={q.sentiment} size="small" />
-                <Chip label={q.platform} size="small" />
-                {q.week && <Chip label={`Week ${q.week}`} size="small" />}
-                <Chip label={q.purchaseIntent} size="small" />
-                {q.competitorMentioned !== 'NONE' && <Chip label={q.competitorMentioned} size="small" />}
-              </Box>
+        <Box
+          ref={listRef}
+          role="list"
+          aria-label="Quote results"
+          tabIndex={0}
+          onScroll={handleScroll}
+          onKeyDown={handleKeyDown}
+          sx={{ maxHeight: { xs: 200, md: 300 }, overflowY: 'auto', outline: 'none' }}
+        >
+          <Box sx={{ height: quotes.length * rowHeight, position: 'relative' }}>
+            <Box sx={{ position: 'absolute', top: offsetY, left: 0, right: 0 }}>
+              {visibleQuotes.map((q, i) => {
+                const actualIndex = startIndex + i;
+                const selected = actualIndex === activeIndex;
+                return (
+                  <Box
+                    key={q.id}
+                    role="listitem"
+                    tabIndex={selected ? 0 : -1}
+                    aria-selected={selected}
+                    sx={{
+                      mb: 2,
+                      px: 1,
+                      backgroundColor: selected ? 'action.hover' : 'inherit',
+                    }}
+                  >
+                    <Typography
+                      variant="body2"
+                      sx={{ fontFamily: 'BMW Motorrad', mb: 0.5 }}
+                    >
+                      "{q.text}"
+                    </Typography>
+                    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                      <Chip label={q.theme} size="small" />
+                      <Chip label={q.sentiment} size="small" />
+                      <Chip label={q.platform} size="small" />
+                      {q.week && <Chip label={`Week ${q.week}`} size="small" />}
+                      <Chip label={q.purchaseIntent} size="small" />
+                      {q.competitorMentioned !== 'NONE' && (
+                        <Chip label={q.competitorMentioned} size="small" />
+                      )}
+                    </Box>
+                  </Box>
+                );
+              })}
             </Box>
-          ))}
+          </Box>
         </Box>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- implement a simple virtualized list inside `QuoteExplorer`
- add keyboard navigation and ARIA roles
- add `react-window` dependency placeholder

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685be82fb78c8331b2bc79f458e153e6