### PR TITLE
Add memoization and debounced quote search

### DIFF
--- a/src/components/R12GSConsumerAnalysis.js
+++ b/src/components/R12GSConsumerAnalysis.js
@@ -28,13 +28,36 @@ const R12GSConsumerAnalysis = ({ selectedMarket, data }) => {
     consumerConcerns = []
   } = marketData;
 
-  const allThemes = Array.from(new Set(consumerQuotes.map((q) => q.theme)));
-  const allSentiments = Array.from(new Set(consumerQuotes.map((q) => q.sentiment)));
-  const allPlatforms = Array.from(new Set(consumerQuotes.map((q) => q.platform)));
-  const allWeeks = Array.from(new Set(consumerQuotes.map((q) => q.week).filter(Boolean)));
-  const allPurchaseIntents = Array.from(new Set(consumerQuotes.map((q) => q.purchaseIntent)));
-  const allCompetitors = Array.from(
-    new Set(consumerQuotes.map((q) => q.competitorMentioned).filter((c) => c && c !== 'NONE'))
+  const allThemes = useMemo(
+    () => Array.from(new Set(consumerQuotes.map((q) => q.theme))),
+    [consumerQuotes]
+  );
+  const allSentiments = useMemo(
+    () => Array.from(new Set(consumerQuotes.map((q) => q.sentiment))),
+    [consumerQuotes]
+  );
+  const allPlatforms = useMemo(
+    () => Array.from(new Set(consumerQuotes.map((q) => q.platform))),
+    [consumerQuotes]
+  );
+  const allWeeks = useMemo(
+    () => Array.from(new Set(consumerQuotes.map((q) => q.week).filter(Boolean))),
+    [consumerQuotes]
+  );
+  const allPurchaseIntents = useMemo(
+    () => Array.from(new Set(consumerQuotes.map((q) => q.purchaseIntent))),
+    [consumerQuotes]
+  );
+  const allCompetitors = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          consumerQuotes
+            .map((q) => q.competitorMentioned)
+            .filter((c) => c && c !== 'NONE')
+        )
+      ),
+    [consumerQuotes]
   );
 
   const [filters, setFilters] = useState({

--- a/src/utils/useDebounce.js
+++ b/src/utils/useDebounce.js
@@ -1,0 +1,14 @@
+import { useState, useEffect } from 'react';
+
+const useDebounce = (value, delay = 300) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;


### PR DESCRIPTION
## Summary
- improve consumer analysis efficiency with useMemo for filter option arrays
- add custom `useDebounce` hook
- implement debounced search in QuoteExplorer

## Testing
- `npm run lint`
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_b_685bea2b81bc8331b0755294cb7ac2a4