### PR TITLE
Add PDF vector store uploader

### DIFF
--- a/AI_CHAT_SETUP.md
+++ b/AI_CHAT_SETUP.md
@@ -58,6 +58,16 @@ VS_STORE_ID=your_vector_store_id_here
 VS_REPORT_STORE_ID=your_report_vector_store_id_here
 ```
 
+### Uploading Report PDFs
+
+Create a vector store containing the PDFs from `vector_reports/`:
+
+```bash
+node scripts/upload_report_vectors.js
+```
+
+Copy the returned ID into `.env` as `VS_REPORT_STORE_ID`.
+
 ### Running the Application
 
 #### Development Mode (React only)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ npm run generate-market-introductions
    - Zoom controls
    - Page navigation
 
+## Report Vector Store
+
+Upload the PDFs in `vector_reports/` to an OpenAI vector store so the chat
+assistant can reference them.
+
+```bash
+node scripts/upload_report_vectors.js
+```
+
+The script prints a vector store ID. Add this ID to your `.env` file as
+`VS_REPORT_STORE_ID`.
+
 ## Running the Dashboard
 
 1. Start the development server:

--- a/scripts/upload_report_vectors.js
+++ b/scripts/upload_report_vectors.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const OpenAI = require('openai').default;
+require('dotenv').config();
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function main() {
+  const pdfDir = path.join(__dirname, '../vector_reports');
+  const pdfPaths = fs
+    .readdirSync(pdfDir)
+    .filter((f) => f.toLowerCase().endsWith('.pdf'))
+    .map((f) => path.join(pdfDir, f));
+
+  if (pdfPaths.length === 0) {
+    console.error('No PDF files found in', pdfDir);
+    return;
+  }
+
+  console.log('Creating vector store...');
+  const store = await openai.beta.vectorStores.create({ name: 'bmw-report-vectors' });
+  console.log('Created vector store:', store.id);
+
+  console.log('Uploading PDFs...');
+  await openai.beta.vectorStores.fileBatches.uploadAndPoll(store.id, {
+    files: pdfPaths.map((p) => fs.createReadStream(p)),
+  });
+
+  console.log('Upload complete. Vector store ID:', store.id);
+}
+
+main().catch((err) => {
+  console.error('Error uploading report vectors:', err);
+});


### PR DESCRIPTION
## Summary
- add `scripts/upload_report_vectors.js` for uploading report PDFs
- document vector store setup in README and AI_CHAT_SETUP

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_68627842d4c08331ace01938d4951f0d