### PR TITLE
Add reports vector store env helper

### DIFF
--- a/AI_CHAT_SETUP.md
+++ b/AI_CHAT_SETUP.md
@@ -55,6 +55,7 @@ Make sure your `.env` file contains:
 ```
 OPENAI_API_KEY=your_openai_api_key_here
 VS_STORE_ID=your_vector_store_id_here
+VS_REPORTS_STORE_ID=your_reports_vector_store_id_here
 ```
 
 ### Running the Application

--- a/config/getReportVectorStoreId.js
+++ b/config/getReportVectorStoreId.js
@@ -1,0 +1,9 @@
+function getReportVectorStoreId() {
+  return (
+    process.env.VS_REPORTS_STORE_ID ||
+    process.env.REACT_APP_VS_REPORTS_STORE_ID ||
+    ""
+  );
+}
+
+module.exports = { getReportVectorStoreId };

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ app.use(express.static(path.join(__dirname, "build")));
 
 // OpenAI setup
 const OpenAI = require("openai").default;
+const { getReportVectorStoreId } = require("./config/getReportVectorStoreId");
 
 let openai = null;
 if (process.env.OPENAI_API_KEY) {
@@ -29,6 +30,9 @@ if (process.env.OPENAI_API_KEY) {
 // Prefer VS_STORE_ID but fall back to REACT_APP_VS_STORE_ID for client and server environments
 const VECTOR_STORE_ID =
   process.env.VS_STORE_ID || process.env.REACT_APP_VS_STORE_ID;
+
+// Prefer VS_REPORTS_STORE_ID but fall back to client-side variable
+const REPORTS_VECTOR_STORE_ID = getReportVectorStoreId();
 
 // Test chat endpoint (simple, no vector store)
 app.post("/api/test-chat", async (req, res) => {
@@ -250,6 +254,14 @@ if (process.env.NODE_ENV !== 'production') {
     );
     console.log(
       `🎯 Vector Store ID: ${process.env.VS_STORE_ID || "Not configured"}`
+    );
+    console.log(
+      `📑 Reports Vector Store ID configured: ${
+        REPORTS_VECTOR_STORE_ID ? "Yes" : "No"
+      }`
+    );
+    console.log(
+      `📂 Reports Vector Store ID: ${REPORTS_VECTOR_STORE_ID || "Not configured"}`
     );
     console.log(
       `🤖 AI Model: ${require("./ai/system-prompt").getAIConfig().model}`


### PR DESCRIPTION
## Summary
- add helper to retrieve `VS_REPORTS_STORE_ID`
- document reports store ID environment variable
- log reports vector store ID on server startup

## Testing
- `npm test -- --watchAll=false`
- `npm run lint` *(fails: testing-library/no-container)*

------
https://chatgpt.com/codex/tasks/task_b_68628033838c83319c9e7fa1644216b9