### PR TITLE
Add script and docs for report vector store

### DIFF
--- a/AI_INSIGHTS_INTEGRATION.md
+++ b/AI_INSIGHTS_INTEGRATION.md
@@ -148,6 +148,9 @@ REACT_APP_OPENAI_API_KEY=your_openai_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 ```
 
+For steps to upload PDF reports to a vector store, see
+[REPORT_VECTOR_STORE_SETUP.md](REPORT_VECTOR_STORE_SETUP.md).
+
 ## Troubleshooting
 
 ### Common Issues

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ npm run generate-r12gs-consumer-data
    - Zoom controls
    - Page navigation
 
+## Vector Store Setup
+
+To enable AI search of the PDF reports, upload the files in `vector_reports/` to
+a new OpenAI vector store:
+
+```bash
+node scripts/create_report_vector_store.js
+```
+
+Copy the printed ID and set it in your `.env` file as `VS_REPORTS_STORE_ID`.
+See [REPORT_VECTOR_STORE_SETUP.md](REPORT_VECTOR_STORE_SETUP.md) for details.
+
 ## Running the Dashboard
 
 1. Start the development server:

--- a/REPORT_VECTOR_STORE_SETUP.md
+++ b/REPORT_VECTOR_STORE_SETUP.md
@@ -1,0 +1,21 @@
+# Report Vector Store Setup
+
+This project can search market PDF reports using an OpenAI vector store. The repository includes sample PDFs in `vector_reports/`.
+
+## Creating the Vector Store
+
+1. Ensure the `OPENAI_API_KEY` environment variable is configured.
+2. Run the upload script:
+   ```bash
+   node scripts/create_report_vector_store.js
+   ```
+3. The script uploads all PDFs from `vector_reports/` and prints the new store ID.
+
+## Configuring the Application
+
+Add the returned ID to your `.env` file:
+```bash
+VS_REPORTS_STORE_ID=your_new_store_id
+```
+
+The chat assistant continues to use `VS_STORE_ID` for the main market data vector store.

--- a/scripts/create_report_vector_store.js
+++ b/scripts/create_report_vector_store.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const OpenAI = require('openai').default;
+
+async function main() {
+  if (!process.env.OPENAI_API_KEY) {
+    console.error('OPENAI_API_KEY environment variable not set');
+    process.exit(1);
+  }
+
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+  const reportsDir = path.join(__dirname, '../vector_reports');
+  const pdfFiles = fs.readdirSync(reportsDir).filter((f) => f.endsWith('.pdf'));
+  if (pdfFiles.length === 0) {
+    console.error('No PDF files found in vector_reports/');
+    process.exit(1);
+  }
+
+  const fileStreams = pdfFiles.map((file) =>
+    fs.createReadStream(path.join(reportsDir, file))
+  );
+
+  console.log(`Uploading ${pdfFiles.length} PDFs to a new vector store...`);
+
+  const vectorStore = await openai.vectorStores.create({
+    name: 'BMW Report Vector Store',
+  });
+
+  await openai.vectorStores.fileBatches.uploadAndPoll(vectorStore.id, {
+    files: fileStreams,
+  });
+
+  console.log('Vector store created successfully!');
+  console.log('Store ID:', vectorStore.id);
+}
+
+main().catch((err) => {
+  console.error('Failed to create report vector store:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `scripts/create_report_vector_store.js` for uploading `vector_reports/` PDFs
- document how to run this script and set `VS_REPORTS_STORE_ID`
- reference the setup doc from README and AI_INSIGHTS_INTEGRATION

## Testing
- `npm test --silent`
- `npm run lint` *(fails: testing-library/no-container)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_b_68629bbfd52083319b648d26b2b0f71b